### PR TITLE
Don't add interior require paths

### DIFF
--- a/asposecloud.gemspec
+++ b/asposecloud.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib","lib/Barcode","lib/Cells","lib/Common","lib/Ocr","lib/Pdf","lib/Slides","lib/Storage","lib/Words", "lib/tasks", "lib/Email"]
+  spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
All of these paths are added to the ruby load path which can then conflict with other gems or application files. Only lib needs to be added.

See sj26/rspec_junit_formatter#36 for an example.